### PR TITLE
don't use instance initialisers for observed properties

### DIFF
--- a/src/components/error.ts
+++ b/src/components/error.ts
@@ -9,7 +9,12 @@ export class Error extends LitElement {
     message: { type: String },
   };
 
-  public message = '';
+  public message: string;
+
+  constructor() {
+    super();
+    this.message = '';
+  }
 
   static styles = [
     borderBox,

--- a/src/components/input.ts
+++ b/src/components/input.ts
@@ -14,8 +14,14 @@ export class Input extends LitElement {
   private _inputRef: Ref<HTMLInputElement> = createRef();
   private _checkboxRef: Ref<HTMLInputElement> = createRef();
 
-  value = '';
-  unicode = false;
+  public value: string;
+  public unicode: boolean;
+
+  constructor() {
+    super();
+    this.value = '';
+    this.unicode = false;
+  }
 
   static styles = [
     borderBox,

--- a/src/components/pattern.ts
+++ b/src/components/pattern.ts
@@ -12,10 +12,18 @@ export class Pattern extends LitElement {
     pattern: { type: String },
   };
 
-  public highlightA: number[] = [];
-  public highlightB: number[] = [];
-  public included: number[] = [];
-  public pattern = '';
+  public highlightA: number[];
+  public highlightB: number[];
+  public included: number[];
+  public pattern: string;
+
+  constructor() {
+    super();
+    this.highlightA = [];
+    this.highlightB = [];
+    this.included = [];
+    this.pattern = '';
+  }
 
   static styles = [
     borderBox,

--- a/src/components/redos-unsafe.ts
+++ b/src/components/redos-unsafe.ts
@@ -13,7 +13,12 @@ export class RedosUnsafe extends LitElement {
 
   public error!: RedosDetectorError;
   public backtrackCount!: number;
-  public maybe = false;
+  public maybe: boolean;
+
+  constructor() {
+    super();
+    this.maybe = false;
+  }
 
   static styles = [
     borderBox,

--- a/src/components/root.ts
+++ b/src/components/root.ts
@@ -131,13 +131,11 @@ export class Root extends LitElement {
     `,
   ];
 
-  private _calculateHandle: CalculateHandle | null = null;
-  private _version: string | null = null;
-  private _highlightA: Set<number> = new Set();
-  private _highlightB: Set<number> = new Set();
-  private _result: ResultErrorLoading = {
-    type: 'loading',
-  };
+  private _calculateHandle: CalculateHandle | null;
+  private _version: string | null;
+  private _highlightA: Set<number>;
+  private _highlightB: Set<number>;
+  private _result: ResultErrorLoading;
   private _inputRef: Ref<Input> = createRef();
 
   private _pattern: string | null = null;
@@ -170,6 +168,17 @@ export class Root extends LitElement {
 
     this.requestUpdate('unicode', old);
     if (old !== null) this._dispatchChange();
+  }
+
+  constructor() {
+    super();
+    this._calculateHandle = null;
+    this._version = null;
+    this._highlightA = new Set();
+    this._highlightB = new Set();
+    this._result = {
+      type: 'loading',
+    };
   }
 
   private _dispatchChange(): void {

--- a/src/components/version.ts
+++ b/src/components/version.ts
@@ -8,7 +8,12 @@ export class Version extends LitElement {
     version: { type: String },
   };
 
-  public version = '';
+  public version: string;
+
+  constructor() {
+    super();
+    this.version = '';
+  }
 
   static styles = [
     borderBox,


### PR DESCRIPTION
Because it's wrong and a parcel update then caused the break when it became spec compliant.

See the docs on https://lit.dev/docs/components/properties/#internal-reactive-state

>[Class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) have a problematic interaction with reactive properties. Class fields are defined on the element instance. Reactive properties are defined as accessors on the element prototype. According to the rules of JavaScript, an instance property takes precedence over and effectively hides a prototype property. This means that reactive property accessors do not function when class fields are used. When a property is set, the element does not update.